### PR TITLE
fix ssot v2.02 submodules to correct commits

### DIFF
--- a/class_dict.json
+++ b/class_dict.json
@@ -186,7 +186,7 @@
             "ow": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table",
             "k": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table",
             "nb": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table",
-            "hll": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/iati-organisations/iati-organisation/document-link/category",
+            "hll": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/iati-organisations/iati-organisation/total-budget/period-start",
             "xref|std|std-ref": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/codelists/CRSChannelCode",
             "std|std-ref": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/codelists/ConditionType",
             "problematic": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/codelists/OrganisationRegistrationAgency"
@@ -226,16 +226,13 @@
         },
         "tr": {
             "row-odd": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table",
-            "row-even": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table",
-            "withdrawn|row-even": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/codelists/CRSChannelCode",
-            "withdrawn|row-odd": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/codelists/CRSChannelCode"
+            "row-even": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table"
         },
         "th": {
             "head": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table"
         },
         "tbody": {
-            "None": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table",
-            "withdrawn": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/codelists/BudgetIdentifierVocabulary"
+            "None": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table"
         },
         "td": {
             "None": "IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/organisation-standard/summary-table"

--- a/href_list.csv
+++ b/href_list.csv
@@ -680,6 +680,16 @@ http://reference.iatistandard.org/201/rulesets/,IATI-Standard-SSOT-version-2.01/
 http://reference.iatistandard.org/201/schema/,IATI-Standard-SSOT-version-2.01/docs/en/_build/dirhtml
 http://reference.iatistandard.org/201/upgrades/integer-upgrade-to-2-01/,IATI-Standard-SSOT-version-2.01/docs/en/_build/dirhtml
 http://reference.iatistandard.org/201/upgrades/integer-upgrade-to-2-01/2-01-changes/,IATI-Standard-SSOT-version-2.01/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/activity-standard/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/activity-standard/summary-table/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/codelists/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/namespaces-extensions/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/organisation-standard/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/organisation-standard/summary-table/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/rulesets/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/schema/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/upgrades/decimal-upgrade-to-2-02/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
+http://reference.iatistandard.org/202/upgrades/decimal-upgrade-to-2-02/2-02-changes/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml
 http://reference.iatistandard.org/203/activity-standard/,IATI-Standard-SSOT-version-2.03/docs/en/_build/dirhtml
 http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/humanitarian-scope/,IATI-Guidance/en/_build/dirhtml/covid-19
 http://reference.iatistandard.org/203/activity-standard/iati-activities/iati-activity/location/location-reach/,IATI-Guidance/en/_build/dirhtml/sub-national-locations-all
@@ -885,6 +895,7 @@ https://iatistandard.org/en/iati-standard/102/activities-standard/sector/,IATI-U
 https://iatistandard.org/en/iati-standard/105/codelists/budgetidentifier/,IATI-Developer-Documentation/_build/dirhtml/codelist-api
 https://iatistandard.org/en/iati-standard/201/codelists/organisationtype/,IATI-Standard-SSOT-version-2.01/docs/en/_build/dirhtml/codelists
 https://iatistandard.org/en/iati-standard/201/codelists/policymarker/,IATI-Standard-SSOT-version-2.01/docs/en/_build/dirhtml/codelists/PolicySignificance
+https://iatistandard.org/en/iati-standard/202/codelists/policymarker/,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/codelists/PolicySignificance
 https://iatistandard.org/en/iati-standard/203/activity-standard/,IATI-Developer-Documentation/_build/dirhtml/ssot
 https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/conditions/condition/narrative/,IATI-Guidance/en/_build/dirhtml/conditions
 https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/iati-identifier/,IATI-Developer-Documentation/_build/dirhtml/old-datastore/reference/data-api

--- a/unknown_words.csv
+++ b/unknown_words.csv
@@ -203,7 +203,6 @@ multiliateral,IATI-Standard-SSOT-version-1.01/101.new/organisation-standard/budg
 musthave,IATI-Standard-SSOT-version-1.03/103.new/activity-schema-table
 nopercentage,IATI-Standard-SSOT-version-1.03/103.new/activity-schema-table
 occurance,IATI-Standard-SSOT-version-2.03/docs/en/_build/dirhtml/activity-standard/iati-activities/iati-activity/result/indicator/baseline
-occurance,IATI-Standard-SSOT-version-2.02/docs/en/_build/dirhtml/activity-standard/iati-activities/iati-activity/result/indicator/baseline
 ofofficially,IATI-Standard-SSOT-version-1.03/103.new/activity-schema-table
 opinoin,IATI-Standard-SSOT-version-1.03/103.new/updates/decimal-upgrade-to-1-04
 orany,IATI-Standard-SSOT-version-1.03/103.new/activity-schema-table


### PR DESCRIPTION
## Summary 

The Submodules for version-2.02 branch were accidentally changed to version-2.03 branches in 4d29ea2

This corrects that error and fixes: https://trello.com/c/j43ZW6tL/88-error-in-202-default-aid-type-element

## Details

I ran `./build.sh` on my local machine with these changes and see the correct Changlelog on the page that was pointed out as incorrect:

After:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/60047271/103781407-3bfbaf80-502e-11eb-8c97-6e50f4f9ac69.png">

Before: 
<img width="808" alt="image" src="https://user-images.githubusercontent.com/60047271/103781448-49189e80-502e-11eb-9b8f-c03b8739c181.png">
